### PR TITLE
drop spurious constants

### DIFF
--- a/Libplot.xs
+++ b/Libplot.xs
@@ -86,18 +86,6 @@ int arg;
     case 'Z':
 	break;
     case '_':
-	if (strEQ(name, "__BEGIN_DECLS"))
-#ifdef __BEGIN_DECLS
-	    return __BEGIN_DECLS;
-#else
-	    goto not_there;
-#endif
-	if (strEQ(name, "__END_DECLS"))
-#ifdef __END_DECLS
-	    return __END_DECLS;
-#else
-	    goto not_there;
-#endif
 	if (strEQ(name, "___const"))
 #ifdef ___const
 	    return ___const;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Graphics-Libplot.
We thought you might be interested in it too.

    Description: drop spurious constants
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1075172
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-08-09
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libgraphics-libplot-perl/raw/master/debian/patches/gcc-14.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
